### PR TITLE
Update file_upload_controller.js to use MediaSource

### DIFF
--- a/app/javascript/controllers/file_upload_controller.js
+++ b/app/javascript/controllers/file_upload_controller.js
@@ -52,7 +52,7 @@ export default class extends Controller {
       }
     }
       
-    img.src = URL.createObjectURL(mediaSource);
+    this.#createPreviewFallback(file)
   }
   
   #createPreviewFallback (file) {

--- a/app/javascript/controllers/file_upload_controller.js
+++ b/app/javascript/controllers/file_upload_controller.js
@@ -6,8 +6,7 @@ export default class extends Controller {
 
   select(event) {
     const file = event.currentTarget.files[0]
-    this.imageTarget.src = window.URL.createObjectURL(file)
-    this.imageTarget.srcset = window.URL.createObjectURL(file)
+    this.#createPreview(file)
     this.imageTarget.classList.remove(this.visibilityClass)
     this.errorTarget.classList.add(this.visibilityClass)
   }
@@ -25,5 +24,40 @@ export default class extends Controller {
     this.activityTarget.classList.add(this.visibilityClass)
     this.errorTarget.classList.remove(this.visibilityClass)
     console.error(event.detail.error)
+  }
+  
+  #createPreview (file) {
+    const img = this.imageTarget;
+    
+    // Browser may not support MediaSource
+    if (!("MediaSource" in window)) {
+      this.#createPreviewFallback(file)
+      return
+    }
+    
+    const mediaSource = new MediaSource();
+    
+    // Older browsers may not have srcObject
+    if ('srcObject' in img) {
+      try {
+        img.srcObject = mediaSource;
+        return
+      } catch (err) {
+        if (err.name !== "TypeError") {
+          throw err;
+        }
+        // Even if they do, they may only support MediaStream
+        this.#createPreviewFallback(file)
+        return
+      }
+    }
+      
+    img.src = URL.createObjectURL(mediaSource);
+  }
+  
+  #createPreviewFallback (file) {
+    const url = URL.createObjectURL(file)
+    this.imageTarget.src = url
+    this.imageTarget.srcset = url
   }
 }


### PR DESCRIPTION
I have no idea if this is actually an issue, but a path you could explore is using MediaSource.

According to MDN: 

> Warning: If you still have code that relies on createObjectURL() to attach streams to media elements, you need to update your code to set srcObject to the MediaStream directly.

https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL#using_object_urls_for_media_streams

I have not tested this, but could be a basis for someone else, I had a few minutes to spare to help.

## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] My code contains tests covering the code I modified
- [ ] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)
